### PR TITLE
Ruby services cleanup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -97,7 +97,7 @@ services:
   groot-recruiters-service:
     build: groot-recruiters-service
     ports:
-      - "3000:3000"
+      - "4567:4567"
     depends_on:
       - db
       - groot-api-gateway

--- a/scripts/database_setup.sql
+++ b/scripts/database_setup.sql
@@ -1,11 +1,10 @@
-CREATE DATABASE IF NOT EXISTS groot_caffeine_service_dev;
 CREATE DATABASE IF NOT EXISTS groot_credits_service;
 CREATE DATABASE IF NOT EXISTS groot_gigs_service;
 CREATE DATABASE IF NOT EXISTS groot_meme_service;
-CREATE DATABASE IF NOT EXISTS groot_merch_service_dev;
-CREATE DATABASE IF NOT EXISTS groot_quote_service_dev;
-CREATE DATABASE IF NOT EXISTS groot_recruiter_service_dev;
-CREATE DATABASE IF NOT EXISTS groot_user_service_dev;
+CREATE DATABASE IF NOT EXISTS groot_merch_service;
+CREATE DATABASE IF NOT EXISTS groot_quote_service;
+CREATE DATABASE IF NOT EXISTS groot_recruiter_service;
+CREATE DATABASE IF NOT EXISTS groot_user_service;
 CREATE USER 'root'@'%' IDENTIFIED BY 'root';
 GRANT ALL PRIVILEGES ON *.* TO 'root'@'%';
 FLUSH PRIVILEGES;

--- a/scripts/docker_settings_init.sh
+++ b/scripts/docker_settings_init.sh
@@ -98,7 +98,13 @@ database:
   user: root
   password: root
   hostname: db
-  name: groot_recruiter_service"
+  name: groot_recruiter_service
+
+test_database:  
+  user: root
+  password: root
+  hostname: db
+  name: groot_recruiter_service_test"
   
 echo "$recruiters_secrets" > groot-recruiters-service/config/secrets.yaml
 

--- a/scripts/docker_settings_init.sh
+++ b/scripts/docker_settings_init.sh
@@ -60,7 +60,7 @@ merch_pi:
     access_key: 'INSERT_TOKEN_HERE'
     ip_address: 'INSERT_IPADDRESS'
 
-development:  
+development_db:  
   user: root
   password: root
   hostname: db
@@ -73,7 +73,7 @@ quotes_secrets="groot:
   access_key: 'GROOT_ACCESS_KEY'
   host: 'http://groot-api-gateway:8000'
 
-development:  
+development_db:  
   user: root
   password: root
   hostname: db
@@ -94,7 +94,7 @@ groot:
 jwt:
   secret: 'SECRET_JWT_TOKEN'
 
-development:  
+development_db:  
   user: root
   password: root
   hostname: db
@@ -107,7 +107,7 @@ users_secrets="groot:
   access_key: 'GROOT_ACCESS_KEY'
   host: 'http://groot-api-gateway:8000'
 
-development:  
+development_db:  
   user: root
   password: root
   hostname: db
@@ -136,7 +136,6 @@ import (
     \"github.com/acm-uiuc/arbor/security\"
 )
 
-const RecruiterToken string = \"\"
 const AuthPrefix = \"Basic \"
 const AuthURL string = \"http://groot-auth-stub-service:8008\"
 const AuthToken string = \"\"

--- a/scripts/docker_settings_init.sh
+++ b/scripts/docker_settings_init.sh
@@ -60,11 +60,11 @@ merch_pi:
     access_key: 'INSERT_TOKEN_HERE'
     ip_address: 'INSERT_IPADDRESS'
 
-development_db:  
+database:  
   user: root
   password: root
   hostname: db
-  name: groot_merch_service_dev"
+  name: groot_merch_service"
 echo "$merch_secrets" > groot-merch-service/config/secrets.yaml
 
 ##### SETUP QUOTES #####
@@ -73,11 +73,11 @@ quotes_secrets="groot:
   access_key: 'GROOT_ACCESS_KEY'
   host: 'http://groot-api-gateway:8000'
 
-development_db:  
+database:  
   user: root
   password: root
   hostname: db
-  name: groot_quote_service_dev"
+  name: groot_quote_service"
 
 echo "$quotes_secrets" > groot-quotes-service/config/secrets.yaml
 
@@ -88,17 +88,18 @@ recruiters_secrets="aws:
     secret_access_key: ''
 
 groot:
-    access_key: 'INSERT_TOKEN_HERE'
+    access_key: 'GROOT_ACCESS_KEY'
     host: 'http://groot-api-gateway:8000'
 
 jwt:
   secret: 'SECRET_JWT_TOKEN'
 
-development_db:  
+database:  
   user: root
   password: root
   hostname: db
-  name: groot_recruiter_service_dev"
+  name: groot_recruiter_service"
+  
 echo "$recruiters_secrets" > groot-recruiters-service/config/secrets.yaml
 
 ##### SETUP USERS #####
@@ -107,11 +108,11 @@ users_secrets="groot:
   access_key: 'GROOT_ACCESS_KEY'
   host: 'http://groot-api-gateway:8000'
 
-development_db:  
+database:  
   user: root
   password: root
   hostname: db
-  name: groot_user_service_dev"
+  name: groot_user_service"
 echo "$users_secrets" > groot-users-service/config/secrets.yaml
 
 ##### SETUP DESKTOP #####


### PR DESCRIPTION
This PR (or set of PRs, see below) standardizes a bunch of things for the Ruby services with docker and in general (Ben has done this for all Python services). Specifically:

- Removes suffix of `_dev` names
- Removes deprecated `RecruiterToken`
- Standardizes database names

Other PRs with this:
- [x] https://github.com/acm-uiuc/groot-api-gateway/pull/66
- [x] https://github.com/acm-uiuc/groot-users-service/pull/13
- [x] https://github.com/acm-uiuc/groot-recruiters-service/pull/11
- [x] https://github.com/acm-uiuc/groot-quotes-service/pull/7
- [x] https://github.com/acm-uiuc/groot-merch-service/pull/12

To make sure this is done correctly in prod, I think we need to rename the databases in the docker db container as well, as well as update all the config files.