### PR TITLE
Add imgur key/value pairs to docker settings

### DIFF
--- a/scripts/docker_settings_init.sh
+++ b/scripts/docker_settings_init.sh
@@ -41,7 +41,10 @@ memes="MYSQL = {
 }
 
 GROOT_ACCESS_TOKEN = ''
-GROOT_SERVICES_URL = 'http://groot-api-gateway:8000'"
+GROOT_SERVICES_URL = 'http://groot-api-gateway:8000'
+
+IMGUR_CLIENT_ID = ''
+IMGUR_CLIENT_SECRET = ''"
 echo "$memes" > groot-meme-service/settings.py
 
 ##### SETUP VOZ #####


### PR DESCRIPTION
The imgur client ids and secrets weren't added to the docker settings, which threw an error when `groot-meme-service` started up.