### PR TITLE
Fix inconsistent recruiter service port in prod

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -102,7 +102,7 @@ services:
   groot-recruiters-service:
     build: groot-recruiters-service
     ports:
-      - "3000:3000"
+      - "4567:4567"
     depends_on:
       - db
       - groot-api-gateway


### PR DESCRIPTION
We were using a different port in recruiter service in prod. This fixes it so that the port is 4567 like in development mode, and like how it is specified in the recruiter service itself.