### PR TITLE
[WIP] Add docker health checks to every service

### DIFF
--- a/docker-compose-prod.yml
+++ b/docker-compose-prod.yml
@@ -15,6 +15,11 @@ services:
       # credentials are as soon as possible, and then service credentials must
       # be also updated accordingly.
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+    healthcheck:
+      test: ["CMD", "/usr/bin/mysql", "--host=localhost", "--port=3306", "--user=root", "--password=$MYSQL_ROOT_PASSWORD", "-e", "'show databases;'"]
+      interval: 1m
+      timeout: 10s
+      retries: 3
 
   groot-api-gateway:
     build: groot-api-gateway
@@ -23,6 +28,11 @@ services:
     volumes: 
       - groot_api_gateway_volume:/var/groot-api-gateway/
     restart: always
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000"]
+      interval: 1m
+      timeout: 10s
+      retries: 3
 
   groot-credits-service:
     build: groot-credits-service
@@ -32,6 +42,11 @@ services:
       - db
       - groot-api-gateway
     restart: always
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8765"]
+      interval: 1m
+      timeout: 10s
+      retries: 3
 
   groot-desktop-frontend:
     build: groot-desktop-frontend
@@ -40,6 +55,11 @@ services:
     ports:
       - "5000:5000"
     restart: always
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5000"]
+      interval: 1m
+      timeout: 10s
+      retries: 3
 
   groot-events-service:
     build: groot-events-service
@@ -50,6 +70,11 @@ services:
     restart: always
     environment:
       TZ: "America/Chicago"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8002"]
+      interval: 1m
+      timeout: 10s
+      retries: 3
 
   groot-gigs-service:
     build: groot-gigs-service
@@ -59,6 +84,11 @@ services:
       - db
       - groot-api-gateway
     restart: always
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8964"]
+      interval: 1m
+      timeout: 10s
+      retries: 3
 
   groot-groups-service:
     build: groot-groups-service
@@ -67,6 +97,11 @@ services:
     depends_on:
       - groot-api-gateway
     restart: always
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9001"]
+      interval: 1m
+      timeout: 10s
+      retries: 3
 
   groot-meme-service:
     build: groot-meme-service
@@ -76,6 +111,11 @@ services:
       - db
       - groot-api-gateway
     restart: always
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:42069"]
+      interval: 1m
+      timeout: 10s
+      retries: 3
 
   groot-merch-service:
     build: groot-merch-service
@@ -85,6 +125,11 @@ services:
       - db
       - groot-api-gateway
     restart: always
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:6969"]
+      interval: 1m
+      timeout: 10s
+      retries: 3
     environment:
       RACK_ENV: "production"
 
@@ -96,6 +141,11 @@ services:
       - db
       - groot-api-gateway
     restart: always
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9494"]
+      interval: 1m
+      timeout: 10s
+      retries: 3
     environment:
       RACK_ENV: "production"
 
@@ -107,6 +157,11 @@ services:
       - db
       - groot-api-gateway
     restart: always
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000"]
+      interval: 1m
+      timeout: 10s
+      retries: 3
     environment:
       RACK_ENV: "production"
 
@@ -120,6 +175,11 @@ services:
     restart: always
     environment:
       RACK_ENV: "production"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8001"]
+      interval: 1m
+      timeout: 10s
+      retries: 3
 
   groot-voz:
     build: groot-voz
@@ -129,7 +189,11 @@ services:
       - db
       - groot-api-gateway
     restart: always
-
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5652"]
+      interval: 1m
+      timeout: 10s
+      retries: 3
 volumes:
     db_data:
     groot_api_gateway_volume:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,11 @@ services:
     restart: always
     environment:
       MYSQL_ROOT_PASSWORD: "root"
+    healthcheck:
+      test: ["CMD", "/usr/bin/mysql", "--host=localhost", "--port=3306", "--user=root", "--password=$MYSQL_ROOT_PASSWORD", "-e", "'show databases;'"]
+      interval: 1m
+      timeout: 10s
+      retries: 3
 
   groot-api-gateway:
     build: groot-api-gateway
@@ -19,6 +24,11 @@ services:
       - groot_api_gateway_volume:/var/groot-api-gateway/
     command: ["./build/groot-api-gateway", "-u"]
     restart: always
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000"]
+      interval: 1m
+      timeout: 10s
+      retries: 3
 
   groot-auth-stub-service:
     build: groot-auth-stub-service
@@ -27,6 +37,11 @@ services:
     volumes:
       - ./groot-auth-stub-service:/usr/src/app
     restart: always
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8008"]
+      interval: 1m
+      timeout: 10s
+      retries: 3
 
   groot-credits-service:
     build: groot-credits-service
@@ -40,6 +55,11 @@ services:
     environment:
       CREDITS_DEBUG: "True"
     restart: always
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8765"]
+      interval: 1m
+      timeout: 10s
+      retries: 3
 
   groot-desktop-frontend:
     build: groot-desktop-frontend
@@ -50,6 +70,11 @@ services:
     volumes:
       - ./groot-desktop-frontend:/usr/src/app
     restart: always
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5000"]
+      interval: 1m
+      timeout: 10s
+      retries: 3
 
   groot-events-service:
     build: groot-events-service
@@ -62,6 +87,11 @@ services:
     restart: always
     environment:
       TZ: "America/Chicago"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8002"]
+      interval: 1m
+      timeout: 10s
+      retries: 3
 
   groot-gigs-service:
     build: groot-gigs-service
@@ -75,6 +105,11 @@ services:
     environment:
       GIG_DEBUG: "True"
     restart: always
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8964"]
+      interval: 1m
+      timeout: 10s
+      retries: 3
 
   groot-groups-service:
     build: groot-groups-service
@@ -85,6 +120,11 @@ services:
     volumes:
       - ./groot-groups-service:/usr/src/app
     restart: always
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9001"]
+      interval: 1m
+      timeout: 10s
+      retries: 3
 
   groot-meme-service:
     build: groot-meme-service
@@ -98,6 +138,11 @@ services:
     environment:
       MEME_DEBUG: "True"
     restart: always
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:42069"]
+      interval: 1m
+      timeout: 10s
+      retries: 3
 
   groot-merch-service:
     build: groot-merch-service
@@ -109,6 +154,11 @@ services:
     volumes:
       - ./groot-merch-service:/usr/src/app
     restart: always
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:6969"]
+      interval: 1m
+      timeout: 10s
+      retries: 3
 
   groot-quotes-service:
     build: groot-quotes-service
@@ -120,6 +170,11 @@ services:
     volumes:
       - ./groot-quotes-service:/usr/src/app
     restart: always
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9494"]
+      interval: 1m
+      timeout: 10s
+      retries: 3
 
   groot-recruiters-service:
     build: groot-recruiters-service
@@ -131,6 +186,11 @@ services:
     volumes:
       - ./groot-recruiters-service:/usr/src/app
     restart: always
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:4567"]
+      interval: 1m
+      timeout: 10s
+      retries: 3
 
   groot-users-service:
     build: groot-users-service
@@ -142,6 +202,11 @@ services:
     volumes:
       - ./groot-users-service:/usr/src/app
     restart: always
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8001"]
+      interval: 1m
+      timeout: 10s
+      retries: 3
 
   groot-voz:
     build: groot-voz
@@ -155,6 +220,11 @@ services:
     environment:
       VOZ_DEBUG: "True"
     restart: always
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:5652"]
+      interval: 1m
+      timeout: 10s
+      retries: 3
 
 volumes:
     db_data:


### PR DESCRIPTION
These can be listened for with the `docker events` command.

I was thinking this could be used as an easy baseline monitoring system, in addition to another service that listens for the generated docker events.